### PR TITLE
Fixed app component error, new CSS error.

### DIFF
--- a/src/Components/App/App.css
+++ b/src/Components/App/App.css
@@ -5,7 +5,6 @@ a {
 }
 
 .App {
-  text-align: none;
   padding: 5%;
   color: var(--main-dark);
   min-height: 100%;
@@ -14,7 +13,7 @@ a {
 .navigation {
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: right;
   gap: 2rem;
   margin: auto;
 }
@@ -37,6 +36,10 @@ a {
 }
 
 /* Code for about.js. */
+.about-container {
+  width: 90vw;
+}
+
 .about-desc {
   width: 730px;
   line-height: 200%;

--- a/src/Components/App/App.css
+++ b/src/Components/App/App.css
@@ -17,13 +17,12 @@ a {
   justify-content: flex-end;
   gap: 2rem;
   margin: auto;
-  /* font-family: "Spectral", serif; */
-  font-size: 1.5rem;
 }
 
 .nav-item {
   text-decoration: none;
   color: var(--main-dark);
+  font-size: 1.5rem;
 }
 
 /* Code for home.js. */

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -9,7 +9,7 @@ function App() {
   return (
     <main className="App">
       <Routes>
-        <Route path="/" element={<Navigation />} className="navigation">
+        <Route path="/" element={<Navigation />}>
           <Route index element={<Home />} />
           <Route path="about" element={<About />} />
           <Route path="projects" element={<Projects />} />

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -1,23 +1,20 @@
-import { Link, Outlet } from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
 import "./App.css";
-import Title from "../Title";
+import About from "../../routes/about.js";
+import Home from "../../routes/home.js";
+import Navigation from "../../routes/navigation.js";
+import Projects from "../../routes/projects.js";
 
 function App() {
   return (
     <main className="App">
-      <nav className="navigation">
-        <Link to="/" className="nav-item">
-          Home
-        </Link>
-        <Link to="/about" className="nav-item">
-          About
-        </Link>
-        <Link to="/projects" className="nav-item">
-          Projects
-        </Link>
-      </nav>
-      <Outlet />
-      <Title />
+      <Routes>
+        <Route path="/" element={<Navigation />} className="navigation">
+          <Route index element={<Home />} />
+          <Route path="about" element={<About />} />
+          <Route path="projects" element={<Projects />} />
+        </Route>
+      </Routes>
     </main>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./Components/App/App.js";
-import About from "./routes/about.js";
-import Projects from "./routes/projects.js";
 import reportWebVitals from "./reportWebVitals";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<App />}>
-          <Route path="about" element={<About />} />
-          <Route path="projects" element={<Projects />} />
-        </Route>
-      </Routes>
+      <App />
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/routes/about.js
+++ b/src/routes/about.js
@@ -1,6 +1,6 @@
 export default function About() {
   return (
-    <main style={{ overflow: "hidden" }}>
+    <main>
       <h1>About.</h1>
       <section className="about-desc">
         <h2>

--- a/src/routes/about.js
+++ b/src/routes/about.js
@@ -2,37 +2,39 @@ export default function About() {
   return (
     <main>
       <h1>About.</h1>
-      <section className="about-desc">
-        <h2>
-          I’m a full-stack software developer, based in the North of England. I
-          like making things and solving problems.
-        </h2>
-        <p>
-          Having previously studied English Literature, and worked in retail,
-          telemarketing and customer service, I decided to pursue a new career
-          path. I wanted to be able to work creatively and productively,
-          engaging fresh opportunities for learning and personal growth. I’ve
-          always been interested in technology, and knew that software
-          development would allow me to do just that.
-        </p>
-        <p>
-          I got stuck in, completing the SheCodes Basics Introduction to Coding
-          and freeCodeCamp’s Responsive Web Design certifications in Spring
-          2022. This led me to the School of Code, where I was selected as one
-          of 150 bootcampers – out of nearly 3000 applicants – to train
-          full-time from April through August in software development.
-        </p>
-        <p>
-          You can find me on{" "}
-          <a href="https://www.linkedin.com/in/madisonclowe/">LinkedIn</a> and
-          on <a href="https://twitter.com/dotmdsn">Twitter</a>. If you're more
-          of a traditionalist, though, feel free to{" "}
-          <a href="mailto:dotmdsn@live.com">send me an email</a>{" "}
-          <em>(opens in a new tab).</em> You can see some of my work under the
-          'Projects' tab, as well as on{" "}
-          <a href="https://github.com/madisonlowe">GitHub</a>.{" "}
-        </p>
-      </section>
+      <div className="about-container">
+        <section className="about-desc">
+          <h2>
+            I’m a full-stack software developer, based in the North of England.
+            I like making things and solving problems.
+          </h2>
+          <p>
+            Having previously studied English Literature, and worked in retail,
+            telemarketing and customer service, I decided to pursue a new career
+            path. I wanted to be able to work creatively and productively,
+            engaging fresh opportunities for learning and personal growth. I’ve
+            always been interested in technology, and knew that software
+            development would allow me to do just that.
+          </p>
+          <p>
+            I got stuck in, completing the SheCodes Basics Introduction to
+            Coding and freeCodeCamp’s Responsive Web Design certifications in
+            Spring 2022. This led me to the School of Code, where I was selected
+            as one of 150 bootcampers – out of nearly 3000 applicants – to train
+            full-time from April through August in software development.
+          </p>
+          <p>
+            You can find me on{" "}
+            <a href="https://www.linkedin.com/in/madisonclowe/">LinkedIn</a> and
+            on <a href="https://twitter.com/dotmdsn">Twitter</a>. If you're more
+            of a traditionalist, though, feel free to{" "}
+            <a href="mailto:dotmdsn@live.com">send me an email</a>{" "}
+            <em>(opens in a new tab).</em> You can see some of my work under the
+            'Projects' tab, as well as on{" "}
+            <a href="https://github.com/madisonlowe">GitHub</a>.{" "}
+          </p>
+        </section>
+      </div>
     </main>
   );
 }

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -1,0 +1,25 @@
+import { descriptors } from "../data";
+import { useState } from "react";
+
+export default function Home() {
+  const [descriptor, setDescriptor] = useState("software developer");
+  const [index, setIndex] = useState(1);
+
+  function handleDescriptor() {
+    let incrementedIndex = (index + 1) % descriptors.length;
+    setIndex(incrementedIndex);
+    let nextDescriptor = descriptors[index];
+    setDescriptor(nextDescriptor);
+  }
+
+  return (
+    <main>
+      <h1 className="home-title">
+        My name is Madison and I am a{" "}
+        <span className="descriptor" onClick={handleDescriptor}>
+          {descriptor}.
+        </span>
+      </h1>
+    </main>
+  );
+}

--- a/src/routes/navigation.js
+++ b/src/routes/navigation.js
@@ -1,0 +1,18 @@
+import { Link, Outlet } from "react-router-dom";
+
+export default function Navigation() {
+  return (
+    <nav>
+      <Link to="/" className="nav-item">
+        Home
+      </Link>
+      <Link to="/about" className="nav-item">
+        About
+      </Link>
+      <Link to="/projects" className="nav-item">
+        Projects
+      </Link>
+      <Outlet />
+    </nav>
+  );
+}

--- a/src/routes/navigation.js
+++ b/src/routes/navigation.js
@@ -2,7 +2,7 @@ import { Link, Outlet } from "react-router-dom";
 
 export default function Navigation() {
   return (
-    <nav>
+    <nav className="navigation">
       <Link to="/" className="nav-item">
         Home
       </Link>


### PR DESCRIPTION
Fixed error with previous route set-up where all components in app would show on all child routes, which meant that my Title component couldn't be displayed on the homepage without being copied to all other pages. Fixed this by adding in a new homepage route and making that subordinate to a navigation route.

New error with CSS, however, where CSS that should apply to the navigation class applies to all of the pages that are manifested within the navigation bar. Can be edited by moving some CSS to the nav-links themselves, but not all CSS rules can be fixed this way. Should be addressed with future fixes.